### PR TITLE
Add tests for node project to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,15 @@ language: python
 python:
   - "2.7"
   - "3.5"
-# command to install dependencies
-install: "cd python && pip install -r requirements.txt"
-# command to run tests
-script: "py.test && node --version"
+install:
+  # Install required node version
+  - "nvm install v6.9.1 && nvm use v6.9.1"
+  # Install python deps. We start in base project directory
+  - "cd python && pip install -r requirements.txt"
+  # Install node deps
+  - "cd ../node && npm install"
+script:
+  # python tests
+  - "cd ../python && py.test"
+  # node tests
+  - "cd ../node && ava"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Travis Build Status](https://travis-ci.org/code-for-nashville/oss-intro-class.svg?branch=master)
+
 # Calculator
 An example open source project that implements calculator functions (add, subtract, multiply, divide) in different
 languages.


### PR DESCRIPTION
This hacks in support for Node testing (even though this is a python project) by installing the correct version of Node with `nvm`, and manually performing tests.

This also adds a build status button to the README.